### PR TITLE
Email address now a mailto

### DIFF
--- a/views/gnome/index/index.hbs
+++ b/views/gnome/index/index.hbs
@@ -63,8 +63,8 @@
     <div class="guadec-login">
       <p class="index-welcome">
         If you have trouble registering, please get in touch at
-        guadec-organization@gnome.org.
-      </p>
+        <mailto href="guadec-organization@gnome.org?Subject=Registration%20trouble">guadec&#x2011;organization@gnome.org</mailto>.
+	</p>
     </div>
 
     </div>


### PR DESCRIPTION
Made registration email address a mailto link
Changed displayed hyphen in address to non-breaking

Signed-off-by: Lisa St.John <code@grimthorpe.org>